### PR TITLE
Add Labels::custom()

### DIFF
--- a/labels.php
+++ b/labels.php
@@ -108,4 +108,20 @@ class Labels
 	{
 		return static::show(Labels::INVERSE, $message, $attributes);
 	}
+	
+	/**
+	 * Create a new custom Labels instance.
+	 * This assumes you have created the appropriate css class for the label type.
+	 *
+	 * @param  string     $type
+	 * @param  string     $message
+	 * @param  array      $attributes
+	 * @return Label
+	 */
+	public static function custom($type, $message, $attributes = array())
+	{
+		$type = 'label-'.(string)$type;
+		
+		return static::show($type, $message, $attributes);
+	}	
 }


### PR DESCRIPTION
New method allows generic labels, not just the 6 predefined classes.
$type argument is type cast to allow use of __toString(), e.g. for a model.
