### PR TITLE
Add with_icon() method to Buttons

### DIFF
--- a/buttons.php
+++ b/buttons.php
@@ -203,7 +203,7 @@ class Buttons
 		}
 
 		// Write output according to tag
-		$tag = ($type == 'link') ? 'link' : 'button';
+		$tag = ($type == 'link') ? 'a' : 'button';
 		return '<'.$tag.HTML::attributes($attributes).'>'.(string)$value.$extra.'</'.$tag.'>';
 	}
 }


### PR DESCRIPTION
So, let's review the changes we discussed earlier.
This is a modification of the Buttons class that adds a `with_icon()` method to it. Some examples of calls :

``` php
  {{ Buttons::large_submit('submit')->with_icon('pencil') }}X
  {{ Buttons::small_inverse_link('', '#')->with_icon('trash_white') }}
  {{ Buttons::warning_link('submit', '#')->append_with_icon('email') }}
  {{ Buttons::success_reset('submit')->prepend_with_icon('users') }}
```

In the code, it's actually a little more than that — some refactoring had to be made since the original Buttons class was static and thus did not allow method chaining. I've handled it a certain way but maybe there's a better way and I'd be glad to hear about it. What I did is create a virtual instance of the Buttons class that gets destroyed when outputing (echo/print etc), storing the state of the current button in a static variable.

In the refactoring a lot of code was moved or modified, but even if the new code looks repetitive it is actually a lot DRYer than the original one since all calls get routed to __toString() which is where I've merged some modifications that were done in several places according to whether you called a submit, a link or a button, etc.

Again, I'm open to discussions on ways to handle even more gracefully.
