### PR TITLE
Add Images class to wrap images in Bootstrap classes

### DIFF
--- a/images.php
+++ b/images.php
@@ -1,0 +1,60 @@
+<?php namespace Bootstrapper;
+
+use \HTML;
+
+/**
+ * Images class for wrapping images with Bootstrap classes
+ *
+ * @package     Bundles
+ * @subpackage  Twitter
+ * @author      Patrick Talmadge - Follow @patricktalmadge
+ *
+ * @see http://twitter.github.com/bootstrap/
+ */
+class Images
+{
+  /**
+   * Creates an image with rounded corners
+   *
+   * @param  string $url        An url
+   * @param  string $alt        An alt text
+   * @param  array  $attributes An array of attributes
+   * @return string             An img tag
+   */
+  public static function rounded($url, $alt = '', $attributes = array())
+  {
+    $attributes = Helpers::add_class($attributes, 'img-'.__FUNCTION__);
+
+    return HTML::image($url, $alt, $attributes);
+  }
+
+  /**
+   * Creates an image masked with a circle
+   *
+   * @param  string $url        An url
+   * @param  string $alt        An alt text
+   * @param  array  $attributes An array of attributes
+   * @return string             An img tag
+   */
+  public static function circle($url, $alt = '', $attributes = array())
+  {
+    $attributes = Helpers::add_class($attributes, 'img-'.__FUNCTION__);
+
+    return HTML::image($url, $alt, $attributes);
+  }
+
+  /**
+   * Creates an image with polaroid borders
+   *
+   * @param  string $url        An url
+   * @param  string $alt        An alt text
+   * @param  array  $attributes An array of attributes
+   * @return string             An img tag
+   */
+  public static function polaroid($url, $alt = '', $attributes = array())
+  {
+    $attributes = Helpers::add_class($attributes, 'img-'.__FUNCTION__);
+
+    return HTML::image($url, $alt, $attributes);
+  }
+}

--- a/start.php
+++ b/start.php
@@ -12,7 +12,7 @@
 
 Autoloader::map(array(
 	'Bootstrapper\\Alert'               => __DIR__.'/alert.php',
-	'Bootstrapper\\Badges'  	    => __DIR__.'/badges.php',
+	'Bootstrapper\\Badges'              => __DIR__.'/badges.php',
 	'Bootstrapper\\Breadcrumbs'         => __DIR__.'/breadcrumbs.php',
 	'Bootstrapper\\ButtonGroup'         => __DIR__.'/buttongroup.php',
 	'Bootstrapper\\Buttons'             => __DIR__.'/buttons.php',
@@ -22,6 +22,7 @@ Autoloader::map(array(
 	'Bootstrapper\\Form'                => __DIR__.'/form.php',
 	'Bootstrapper\\Helpers'             => __DIR__.'/helpers.php',
 	'Bootstrapper\\Icons'               => __DIR__.'/icons.php',
+	'Bootstrapper\\Images'              => __DIR__.'/images.php',
 	'Bootstrapper\\Labels'              => __DIR__.'/labels.php',
 	'Bootstrapper\\Navbar'              => __DIR__.'/navbar.php',
 	'Bootstrapper\\Navigation'          => __DIR__.'/navigation.php',


### PR DESCRIPTION
Allows the following :

``` php
{{ Images::rounded('myimage.jpg') }}
{{ Images::circle('myimage.jpg') }}
{{ Images::polaroid('myimage.jpg') }}
```

In the background it's just a call to `HTML::image` with an added class so, attributes are the same, and it's all Laravel underneath.
You can't do `Images::rounded_polaroid(...)` because as far as I've tested, the Bootstrap classes don't handle it yet, the result is either messy or just plain don't work.
