### PR TITLE
Allows support for strictly informative alerts

### DIFF
--- a/alert.php
+++ b/alert.php
@@ -4,14 +4,14 @@ use \HTML;
 
 /**
  * Alert for creating Twitter Bootstrap style alerts.
- * 
+ *
  * @package     Bundles
  * @subpackage  Twitter
  * @author      Patrick Talmadge - Follow @patricktalmadge
  *
  * @see http://twitter.github.com/bootstrap/
  */
-class Alert 
+class Alert
 {
 	// Alert styles
 	const SUCCESS = 'alert-success';
@@ -34,11 +34,11 @@ class Alert
 		$attributes = Helpers::add_class($attributes, 'alert '.$type);
 
 		$html = '<div'.HTML::attributes($attributes).'>';
-		
+
 		if($enable_close)
 			$html .= '<a class="close" data-dismiss="alert" href="#">&times;</a>';
-		
-		$html .= $message.'</div>'; 
+
+		$html .= $message.'</div>';
 
 		return $html;
 	}
@@ -107,7 +107,7 @@ class Alert
 	{
 		return static::show(Alert::DANGER, $message, $enable_close, $attributes);
 	}
-	
+
 	/**
 	 * Create a new custom Alert.
 	 * This assumes you have created the appropriate css class for the alert type.
@@ -123,5 +123,30 @@ class Alert
 		$type = 'alert-'.(string)$type;
 
 		return static::show($type, $message, $enable_close, $attributes);
+	}
+
+	/**
+	 * Check to see if we're calling an informative alert
+	 *
+	 * @param  string $method     The function called
+	 * @param  array  $parameters Its parameters
+	 * @return Alert              An Alert
+	 */
+	public static function __callStatic($method, $parameters)
+	{
+		// Extract real method and type of alert
+		$method = explode('_', $method);
+		$isOpen = array_get($method, 0) == 'open';
+		$method = array_get($method, 1);
+
+		// If we have an informative alert
+		if($isOpen) {
+			// Fetch parameters
+			$message    = array_get($parameters, 0);
+			$attributes = array_get($parameters, 1);
+
+			return call_user_func('static::'.$method, $message, false, $attributes);
+		}
+		else call_user_func('static::'.$method, $parameters);
 	}
 }


### PR DESCRIPTION
This is something that I think can be made better but I open this for discussions.
Currently whenever you call `Alert::something()` the default behavior is to have the close icon, and the fact is that since that close button requires the Bootstrap-alerts plugin, I don't think it's in its majority used that way.

Now we could change the default of that function, but again that's not the Laravel way so I created a fictive call to allow this :

``` php
{{ Alert::error('Mymessage', true, array(attributes)) }} // Close icon
{{ Alert::open_success('Mymessage', array(attributes)) }} // No close icon
```

Now the `open` keyword is kind of ugly, so I'm open to discussions on something better and yet still short.
If the decisions goes to changing the default to `false`, then we could change the behavior of Alert to this :

``` php
{{ Alert::error('Mymessage', array(attributes)) }} // No close icon
{{ Alert::closable_success('Mymessage', array(attributes)) }} // Close icon
```

And thus definitely get rid of that close argument that just stands in the way, bothering everyone.
