### PR TITLE
Invert Buttons::link parameters order to match Laravel's - Fixes #30

### DIFF
--- a/buttons.php
+++ b/buttons.php
@@ -92,13 +92,13 @@ class Buttons
 	/**
 	 * Create a HTML anchor tag styled like a button element.
 	 *
-	 * @param  string  $value
 	 * @param  string  $url
+	 * @param  string  $value
 	 * @param  array   $attributes
 	 * @param  bool    $hasDropdown
 	 * @return string
 	 */
-	public static function link($value, $url, $attributes = array(), $hasDropdown = false)
+	public static function link($url, $value, $attributes = array(), $hasDropdown = false)
 	{
 		$attributes['href'] = \URL::to($url);
 		return static::storeButton('link', $value, $attributes, $hasDropdown);


### PR DESCRIPTION
Title says it all.

``` php
// Old syntax
{{ Buttons::large_primary_link('text', '#') }}

// New syntax
{{ Buttons::large_primary_link('#', 'text') }}
```
