### PR TITLE
Use Autoloader::namespace instead of manual mapping

### DIFF
--- a/start.php
+++ b/start.php
@@ -12,7 +12,7 @@
 
 $libs_path = __DIR__.'/libraries';
 
-// Autoload Cerberus
+// Autoload Boostrapper
 Autoloader::namespaces(array(
   'Bootstrapper' => Bundle::path('bootstrapper') . 'libraries'
 ));


### PR DESCRIPTION
This changes the default loading method from manually mapping each class to just using `Autoload::namespace` which is more future-proof. Since Bootstrapper is actually namespaced, might as well use it.
