### PR TITLE
Remove type=button from links

### DIFF
--- a/libraries/button.php
+++ b/libraries/button.php
@@ -243,7 +243,11 @@ class Button
         }
 
         // Write output according to tag
-        $tag = ($type == 'link') ? 'a' : 'button';
+        $tag = 'button';
+        if ($type === 'link') {
+            $tag = 'a';
+            unset($attributes['type']);
+        }
 
         return '<'.$tag.HTML::attributes($attributes).'>'.(string)$value.$caret.'</'.$tag.'>';
     }


### PR DESCRIPTION
Button links generates type="button" as one of the parameters, which isn't valid html.
