### PR TITLE
A better way to reduce installation setup

### DIFF
--- a/start.php
+++ b/start.php
@@ -10,6 +10,40 @@
  * @see http://twitter.github.com/bootstrap/
  */
 
+/**
+* Customized by Raftalks
+* ======================
+* Following will help users to modify the config/application.php file 
+* This way, removes the hassle for the bundle user. :)
+**/
+$custom_aliases = array(
+	'Alert'                 => 'Bootstrapper\\Alert',
+	'Badges'                => 'Bootstrapper\\Badges',
+	'Breadcrumbs'           => 'Bootstrapper\\Breadcrumbs',
+	'Buttons'               => 'Bootstrapper\\Buttons',
+	'ButtonGroup'           => 'Bootstrapper\\ButtonGroup',
+	'ButtonToolbar'         => 'Bootstrapper\\ButtonToolbar',
+	'Carousel'              => 'Bootstrapper\\Carousel',
+	'DropdownButton'        => 'Bootstrapper\\DropdownButton',
+	'Form'                  => 'Bootstrapper\\Form',
+	'Helpers'               => 'Bootstrapper\\Helpers',
+	'Icons'                 => 'Bootstrapper\\Icons',
+	'Labels'                => 'Bootstrapper\\Labels',
+	'Navbar'                => 'Bootstrapper\\Navbar',
+	'Navigation'            => 'Bootstrapper\\Navigation',
+	'Paginator'             => 'Bootstrapper\\Paginator',
+	'Progress'              => 'Bootstrapper\\Progress',
+	'SplitDropdownButton'   => 'Bootstrapper\\SplitDropdownButton',
+	'Tabbable'              => 'Bootstrapper\\Tabbable',
+	'Typeahead'             => 'Bootstrapper\\Typeahead',
+
+);
+
+$laravel_aliases = Laravel\Autoloader::$aliases;
+Laravel\Autoloader::$aliases = array_merge($laravel_aliases, $custom_aliases);
+
+//<-- end of the custom addition -->
+
 Autoloader::map(array(
 	'Bootstrapper\\Alert'               => __DIR__.'/alert.php',
 	'Bootstrapper\\Badges'  	    => __DIR__.'/badges.php',


### PR DESCRIPTION
The idea here is to give the bundle user a hassle free installation and usage of the bundle.
The original bundle require customising the config/application.php file to add
the long lines of custom alias to link the namespaces of bootstrapper. instead,
with this commit, it will avoid that step for the bundle user. cheers :)
