### PR TITLE
Use $attributes in Button::with_icon()

### DIFF
--- a/src/Bootstrapper/Button.php
+++ b/src/Bootstrapper/Button.php
@@ -134,7 +134,7 @@ class Button
     public function with_icon($icon, $attributes = array(), $prependIcon = true)
     {
         // Call Icon to create the icon
-        $icon = Icon::make($icon);
+        $icon = Icon::make($icon, $attributes);
 
         // If there was no text, just use the icon, else put a space between
         $value = $this->currentButton['value'];


### PR DESCRIPTION
Make Button::with_icon() forward $attributes to Icon class (i.e. to add icon-white class)

Example:

``` php
Button::success_link('#', 'Link name')
    ->with_icon('plus', array('class' => 'icon-white')),
```
