### PR TITLE
Fix fatal exception in Table::__set

### DIFF
--- a/src/Bootstrapper/Table.php
+++ b/src/Bootstrapper/Table.php
@@ -148,7 +148,7 @@ class Table
     public function __set($column, $content)
     {
         // List known keys
-        $columns = array_get($this->tbody, key($this->tbody));
+        $columns = array_get($this->tbody, key($this->tbody), array());
         $columns = array_keys(is_object($columns) ? $columns->attributes : $columns);
 
         // If we're not replacing something, we're creating, assume classes


### PR DESCRIPTION
Added default parameter to array_get to prevent a fatal exception being thrown by array_keys (line 152), for some reason array_get (line 151) was returning null sometimes.

I discovered this bug while trying to make calculated fields on a table body.
