### PR TITLE
Add jQuery js file before bootstrap js file. Fixes #105

### DIFF
--- a/src/Bootstrapper/BootstrapperServiceProvider.php
+++ b/src/Bootstrapper/BootstrapperServiceProvider.php
@@ -40,7 +40,8 @@ class BootstrapperServiceProvider extends ServiceProvider
 
     $this->app['config']->set('basset::collections.bootstrapper', function($collection) {
       $collection->requireDirectory('packages/patricktalmadge/bootstrapper/css');
-      $collection->requireDirectory('packages/patricktalmadge/bootstrapper/js');
+      $collection->add('packages/patricktalmadge/bootstrapper/js/jquery-1.9.1.min.js');
+      $collection->add('packages/patricktalmadge/bootstrapper/js/bootstrap.min.js');
     });
   }
 }


### PR DESCRIPTION
Bootstrap js file was loaded before jQuery file. Because basset doesn't provides a way to set a sequence you'll have to manually set the sequence through the add method.
