### PR TITLE
Fixed double <li><li></li></li> in paginator links

### DIFF
--- a/src/Bootstrapper/Paginator.php
+++ b/src/Bootstrapper/Paginator.php
@@ -133,7 +133,7 @@ class Paginator extends \Laravel\Paginator
 
             return '<li'.HTML::attributes(compact("class")).'><a href="#">'.HTML::entities($text).'</a></li>';
         } else {
-            return '<li'.HTML::attributes(compact("class")).'>'.$this->link($page, $text, null).'</li>';
+            return $this->link($page, $text, null);
         }
     }
 


### PR DESCRIPTION
Fixed double <li><li></li></li> in paginator links.
This avoid outputing invalid HTML code _and_ solve the issue of the missing left border for the "Previous" paginator button when not on the first page.
