### PR TITLE
Updating README to reflect Blade changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@ php artisan asset:publish patricktalmadge/bootstrapper
 And then add the following to your template view file to include the Twitter Bootstrap CSS and Javascript.
 
 ```php
-{{{ Basset::show('bootstrapper.css') }}}
-{{{ Basset::show('bootstrapper.js') }}}
+{{ Basset::show('bootstrapper.css') }}
+{{ Basset::show('bootstrapper.js') }}
 ```
 
 ## Documentation


### PR DESCRIPTION
Blade changed the way that the braces are handled in Beta 4, 
triple braces now escape and doubles do not. This is a simple
change to reflect this in the README
