### PR TITLE
$this->package being called on wrong method

### DIFF
--- a/src/Bootstrapper/BootstrapperServiceProvider.php
+++ b/src/Bootstrapper/BootstrapperServiceProvider.php
@@ -18,7 +18,6 @@ class BootstrapperServiceProvider extends ServiceProvider
    */
   public function register()
   {
-    $this->package('patricktalmadge/bootstrapper');
 
     $this->app['config']->package('patricktalmadge/bootstrapper', __DIR__. '/../config');
 
@@ -32,6 +31,8 @@ class BootstrapperServiceProvider extends ServiceProvider
    */
   public function boot()
   {
+    $this->package('patricktalmadge/bootstrapper');
+
     if (!is_dir($this->app['path.public'].'/packages/patricktalmadge/')) return false;
 
     if (!is_dir($this->app['path.public'].'/packages/patricktalmadge/')) return false;


### PR DESCRIPTION
I've been getting this error since I installed Bootstrapper:

```
ReflectionException
Class files does not exist
```

So I went to look what was causing it, and it seems `BootstraperServiceProvider.php` is invoking `$this->package(...)` on the `boot` method, instead of `register`, which seemed to be the cause of my problem.
