### PR TITLE
Incorrect Alert markup

### DIFF
--- a/src/Bootstrapper/Alert.php
+++ b/src/Bootstrapper/Alert.php
@@ -37,6 +37,13 @@ class Alert extends Element
     protected $type = Alert::SUCCESS;
 
     /**
+     * The message of the alert
+     *
+     * @var string
+     */
+    protected $message = null;
+
+    /**
      * Whether the current alert is closeable
      *
      * @var boolean
@@ -71,6 +78,8 @@ class Alert extends Element
             $close = Helpers::getContainer('html')->link('#', '&times;', array('class' => 'close', 'data-dismiss' => 'alert'));
             $this->nest($close);
         }
+
+        $this->nest($this->message);
 
         return '<'.$this->element.Helpers::getContainer('html')->attributes($this->attributes).'>'.$this->getContent().$this->close();
     }
@@ -160,10 +169,11 @@ class Alert extends Element
      */
     protected static function show($type, $message, $attributes = array())
     {
-        $instance = new static('div', $message, $attributes);
+        $instance = new static('div', null, $attributes);
 
         // Save given parameters
         $instance->addClass($type);
+        $instance->message = $message;
 
         return $instance;
     }


### PR DESCRIPTION
The `Alert` class is not producing the correct markup when closeable: it's placing the closing anchor after the message, while it should be placed before it. It matters because, as the element has `position:relative`, it ends up in the wrong location.

For instance, `Alert::error('My message')` should be producing

``` html
<div class="alert-error alert">
    <a href="#" class="close" data-dismiss="alert">&times;</a>
    My message
</div>
```

but, instead, produces

``` html
<div class="alert-error alert">
    My message
    <a href="#" class="close" data-dismiss="alert">&times;</a>
</div>
```

This is how the alert looks like with the incorrect markup:
![image](https://f.cloud.github.com/assets/2119933/515915/43f840ac-be8e-11e2-9299-8af0cdbb348a.png)
