### PR TITLE
This is an additional fix for #160

### DIFF
--- a/src/Bootstrapper/Table.php
+++ b/src/Bootstrapper/Table.php
@@ -282,7 +282,7 @@ class Table
      */
     public function render()
     {
-        if(!$this->tbody) return false;
+        if(!$this->tbody) return '';
 
         // Fetch ignored columns
         if (!$this->ignore) $this->ignore = Helpers::getContainer('config')->get('bootstrapper::table.ignore');

--- a/tests/TableTest.php
+++ b/tests/TableTest.php
@@ -133,6 +133,12 @@ class TableTest extends BootstrapperWrapper
     $this->assertHTML($matcher, $fullRow);
   }
 
+  public function testEmptyBody()
+  {
+    $body = Table::body(array())->__toString();
+    $this->assertSame('', $body);
+  }
+
   public function testBody()
   {
     $body = Table::body($this->body)->__toString();


### PR DESCRIPTION
This fix makes sure that Laravel doesn't throw an exception when the tbody is empty and the render method is called.
