### PR TITLE
Fix small CSS issue with Progress bars.

### DIFF
--- a/src/Bootstrapper/Progress.php
+++ b/src/Bootstrapper/Progress.php
@@ -66,7 +66,7 @@ class Progress
     protected static function bar($amount = 0, $style = null)
     {
         // Prepend bar style with 'bar-'
-        $style = $style ? ' progress-bar-b' . $style : null;
+        $style = $style ? ' progress-bar-' . $style : null;
         return '<div class="progress-bar' .$style. '" style="width: ' .$amount. '%;"></div>';
     }
 


### PR DESCRIPTION
The Progress bar class was generating a css class name with an extra "b" in it. This commit simply removes the b that was preventing Bootstrap from showing the different styles of progress bars (warning, danger etc.).
