### PR TITLE
[Bug] Fixed issue with Paginator::make()

### DIFF
--- a/src/Bootstrapper/Paginator.php
+++ b/src/Bootstrapper/Paginator.php
@@ -1,7 +1,7 @@
 <?php
 namespace Bootstrapper;
 
-use Illuminate\Pagination\Paginator as LaravelPaginator;
+use Illuminate\Support\Facades\Paginator as LaravelPaginator;
 
 /**
  * Paginator for creating Twitter Bootstrap pagination.


### PR DESCRIPTION
If you tries to create a manual paginator with `Paginator::make()` this will fail because make it isn't defined in `Illuminate\Pagination\Paginator` but in `Illuminate\Pagination\Environment`.

I've switched the use statement to use the appropriate facade.
