### PR TITLE
Navbar: fix broken pull-right menus

### DIFF
--- a/src/Bootstrapper/Navbar.php
+++ b/src/Bootstrapper/Navbar.php
@@ -190,7 +190,11 @@ class Navbar
 
         // Open navbar containers
         $html  = '<nav'.Helpers::getContainer('html')->attributes($attributes).' role="navigation">';
-        $html .= '<div class="container"><div class="navbar-header">';
+        $html .= '<div class="container">';
+		
+		// --- Header ---
+		if ($this->collapsible || $this->brand)
+			$html .= '<div class="navbar-header">';
 
         // Collapsible button if asked for
         if ($this->collapsible) {
@@ -208,13 +212,18 @@ class Navbar
             $brand = $this->brand;
             if ($brand['escape']) {
                 $html .= Helpers::getContainer('html')->link($this->brand['url'], $this->brand['name'], array('class' => 'navbar-brand'));
-                $html .= '</div>';
             } else {
                 $url = $brand['url'];
                 $text = $brand['name'];
                 $html .= "<a href='$url' class='navbar-brand'>$text</a>";
             }
         }
+		
+		if ($this->collapsible || $this->brand)
+			$html .= '</div>';
+		/// --- Header ---
+		
+		// --- Content ---
         if($this->collapsible)
             $html .= '<div class="navbar-collapse collapse">';
 
@@ -231,6 +240,7 @@ class Navbar
 
         if($this->collapsible)
             $html .= '</div>';
+		// --- Content ---
 
         // Close navbar containers
         $html .= '</div></nav>';


### PR DESCRIPTION
The content of the nabar shouldn't be placed in the same div as the navbar header.

This broke for example menus with the "navbar-right" property (to align them on the right side)
