### PR TITLE
Wrappers for standard Laravel Form functions to add form-control class

### DIFF
--- a/src/Bootstrapper/Form.php
+++ b/src/Bootstrapper/Form.php
@@ -128,7 +128,7 @@ class Form extends FormBuilder
     {
         $attributes['class'] = isset($attributes['class']) ? self::FORM_CONTROL . ' ' . $attributes['class'] : self::FORM_CONTROL;
 
-        return parent::input('datetimelocal',$name, $value, $attributes);
+        return parent::input('datetime-local',$name, $value, $attributes);
     }
 
     public function date($name, $value = null, $attributes = array())

--- a/tests/spec/Bootstrapper/FormSpec.php
+++ b/tests/spec/Bootstrapper/FormSpec.php
@@ -118,29 +118,30 @@ class FormSpec extends ObjectBehavior
     function it_can_show_input()
     {
         $types = [
-            'text',
-            'email',
-            'datetime',
-            'datetimelocal',
-            'date',
-            'month',
-            'time',
-            'week',
-            'number',
-            'url',
-            'search',
-            'tel',
-            'color'
+            'text' => 'text',
+            'email' => 'email',
+            'datetime' => 'datetime',
+            'datetimelocal' => 'datetime-local',
+            'date' => 'date',
+            'month' => 'month',
+            'time' => 'time',
+            'week' => 'week',
+            'number' => 'number',
+            'url' => 'url',
+            'search' => 'search',
+            'tel' => 'tel',
+            'color' => 'color'
         ];
-        foreach ($types as $type) {
-            $this->$type('foo','bar',['class' => 'baz'])->shouldBe('<input class="form-control baz" name="foo" type="' . $type . '" value="bar">');
+        foreach ($types as $type => $expected) {
+            $this->$type('foo','bar',['class' => 'baz'])->shouldBe('<input class="form-control baz" name="foo" type="' . $expected . '" value="bar">');
         }
     }
 
     function it_can_show_password()
     {
-        $this->password('foo',['class' => 'foo'])->shouldBe('<input class="form-control foo" name="foo" type="password" value="">');
+        $this->password('foo',['class' => 'baz'])->shouldBe('<input class="form-control baz" name="foo" type="password" value="">');
     }
+
 }
 
 class Foo


### PR DESCRIPTION
Added wrappers for standard form methods and increased scope to all supported HTML5 types in Bootstrap 3
