### PR TITLE
Fixing facade accessor

### DIFF
--- a/src/Bootstrapper/Facades/Accordion.php
+++ b/src/Bootstrapper/Facades/Accordion.php
@@ -20,6 +20,6 @@ class Accordion extends BootstrapperFacade
      */
     protected static function getFacadeAccessor()
     {
-        return 'accordion';
+        return 'bootstrapper::accordion';
     }
 }

--- a/src/Bootstrapper/Facades/Alert.php
+++ b/src/Bootstrapper/Facades/Alert.php
@@ -24,7 +24,7 @@ class Alert extends BootstrapperFacade
      */
     protected static function getFacadeAccessor()
     {
-        return 'alert';
+        return 'bootstrapper::alert';
     }
 
 }

--- a/src/Bootstrapper/Facades/Badge.php
+++ b/src/Bootstrapper/Facades/Badge.php
@@ -20,7 +20,7 @@ class Badge extends BootstrapperFacade
      */
     protected static function getFacadeAccessor()
     {
-        return 'badge';
+        return 'bootstrapper::badge';
     }
 
 }

--- a/src/Bootstrapper/Facades/Breadcrumb.php
+++ b/src/Bootstrapper/Facades/Breadcrumb.php
@@ -20,7 +20,7 @@ class Breadcrumb extends BootstrapperFacade
      */
     protected static function getFacadeAccessor()
     {
-        return 'breadcrumb';
+        return 'bootstrapper::breadcrumb';
     }
 
 }

--- a/src/Bootstrapper/Facades/Button.php
+++ b/src/Bootstrapper/Facades/Button.php
@@ -29,7 +29,7 @@ class Button extends BootstrapperFacade
      */
     protected static function getFacadeAccessor()
     {
-        return 'button';
+        return 'bootstrapper::button';
     }
 
 }

--- a/src/Bootstrapper/Facades/ButtonGroup.php
+++ b/src/Bootstrapper/Facades/ButtonGroup.php
@@ -30,7 +30,7 @@ class ButtonGroup extends BootstrapperFacade
      */
     protected static function getFacadeAccessor()
     {
-        return 'buttongroup';
+        return 'bootstrapper::buttongroup';
     }
 
 }

--- a/src/Bootstrapper/Facades/Carousel.php
+++ b/src/Bootstrapper/Facades/Carousel.php
@@ -20,7 +20,7 @@ class Carousel extends BootstrapperFacade
      */
     protected static function getFacadeAccessor()
     {
-        return 'carousel';
+        return 'bootstrapper::carousel';
     }
 
 }

--- a/src/Bootstrapper/Facades/ControlGroup.php
+++ b/src/Bootstrapper/Facades/ControlGroup.php
@@ -20,7 +20,7 @@ class ControlGroup extends BootstrapperFacade
      */
     protected static function getFacadeAccessor()
     {
-        return 'controlgroup';
+        return 'bootstrapper::controlgroup';
     }
 
 }

--- a/src/Bootstrapper/Facades/DropdownButton.php
+++ b/src/Bootstrapper/Facades/DropdownButton.php
@@ -29,7 +29,7 @@ class DropdownButton extends BootstrapperFacade
      */
     protected static function getFacadeAccessor()
     {
-        return 'dropdownbutton';
+        return 'bootstrapper::dropdownbutton';
     }
 
 }

--- a/src/Bootstrapper/Facades/Icon.php
+++ b/src/Bootstrapper/Facades/Icon.php
@@ -22,7 +22,7 @@ class Icon extends Facade
      */
     protected static function getFacadeAccessor()
     {
-        return 'icon';
+        return 'bootstrapper::icon';
     }
 
 }

--- a/src/Bootstrapper/Facades/Image.php
+++ b/src/Bootstrapper/Facades/Image.php
@@ -25,7 +25,7 @@ class Image extends BootstrapperFacade
      */
     protected static function getFacadeAccessor()
     {
-        return 'image';
+        return 'bootstrapper::image';
     }
 
 }

--- a/src/Bootstrapper/Facades/InputGroup.php
+++ b/src/Bootstrapper/Facades/InputGroup.php
@@ -23,7 +23,7 @@ class InputGroup extends BootstrapperFacade
      */
     protected static function getFacadeAccessor()
     {
-        return 'inputgroup';
+        return 'bootstrapper::inputgroup';
     }
 
 }

--- a/src/Bootstrapper/Facades/Label.php
+++ b/src/Bootstrapper/Facades/Label.php
@@ -27,7 +27,7 @@ class Label extends BootstrapperFacade
      */
     protected static function getFacadeAccessor()
     {
-        return 'label';
+        return 'bootstrapper::label';
     }
 
 }

--- a/src/Bootstrapper/Facades/MediaObject.php
+++ b/src/Bootstrapper/Facades/MediaObject.php
@@ -20,7 +20,7 @@ class MediaObject extends BootstrapperFacade
      */
     protected static function getFacadeAccessor()
     {
-        return 'mediaobject';
+        return 'bootstrapper::mediaobject';
     }
 
 }

--- a/src/Bootstrapper/Facades/Modal.php
+++ b/src/Bootstrapper/Facades/Modal.php
@@ -19,7 +19,7 @@ class Modal extends BootstrapperFacade
      */
     protected static function getFacadeAccessor()
     {
-        return 'modal';
+        return 'bootstrapper::modal';
     }
 
 }

--- a/src/Bootstrapper/Facades/Navbar.php
+++ b/src/Bootstrapper/Facades/Navbar.php
@@ -24,7 +24,7 @@ class Navbar extends BootstrapperFacade
      */
     protected static function getFacadeAccessor()
     {
-        return 'navbar';
+        return 'bootstrapper::navbar';
     }
 
 }

--- a/src/Bootstrapper/Facades/Navigation.php
+++ b/src/Bootstrapper/Facades/Navigation.php
@@ -25,7 +25,7 @@ class Navigation extends BootstrapperFacade
      */
     protected static function getFacadeAccessor()
     {
-        return 'navigation';
+        return 'bootstrapper::navigation';
     }
 
 }

--- a/src/Bootstrapper/Facades/Panel.php
+++ b/src/Bootstrapper/Facades/Panel.php
@@ -26,7 +26,7 @@ class Panel extends BootstrapperFacade
      */
     protected static function getFacadeAccessor()
     {
-        return 'panel';
+        return 'bootstrapper::panel';
     }
 
 }

--- a/src/Bootstrapper/Facades/ProgressBar.php
+++ b/src/Bootstrapper/Facades/ProgressBar.php
@@ -26,7 +26,7 @@ class ProgressBar extends BootstrapperFacade
      */
     protected static function getFacadeAccessor()
     {
-        return 'progressbar';
+        return 'bootstrapper::progressbar';
     }
 
 }

--- a/src/Bootstrapper/Facades/Tabbable.php
+++ b/src/Bootstrapper/Facades/Tabbable.php
@@ -22,7 +22,7 @@ class Tabbable extends BootstrapperFacade
      */
     protected static function getFacadeAccessor()
     {
-        return 'tabbable';
+        return 'bootstrapper::tabbable';
     }
 
 }

--- a/src/Bootstrapper/Facades/Table.php
+++ b/src/Bootstrapper/Facades/Table.php
@@ -25,7 +25,7 @@ class Table extends BootstrapperFacade
      */
     protected static function getFacadeAccessor()
     {
-        return 'table';
+        return 'bootstrapper::table';
     }
 
 }

--- a/src/Bootstrapper/Facades/Thumbnail.php
+++ b/src/Bootstrapper/Facades/Thumbnail.php
@@ -20,7 +20,7 @@ class Thumbnail extends BootstrapperFacade
      */
     protected static function getFacadeAccessor()
     {
-        return 'thumbnail';
+        return 'bootstrapper::thumbnail';
     }
 
 }


### PR DESCRIPTION
Original facade accessors began to failure on Laravel 4.2.11. After changing them to 'bootstrapper::*' as registered in the service provider, they worked again.
