### PR TITLE
Remove autoroute check from dropdownShouldBeActive

### DIFF
--- a/src/Bootstrapper/Navigation.php
+++ b/src/Bootstrapper/Navigation.php
@@ -267,11 +267,9 @@ class Navigation extends RenderedObject
      */
     protected function dropdownShouldBeActive(array $dropdown)
     {
-        if ($this->autoroute) {
-            foreach ($dropdown[1] as $item) {
-                if ($this->itemShouldBeActive($item)) {
-                    return true;
-                }
+        foreach ($dropdown[1] as $item) {
+            if ($this->itemShouldBeActive($item)) {
+                return true;
             }
         }
         return false;


### PR DESCRIPTION
The autoroute check was redundant. The check would also break functionality where the user is manually managing link active status and has autorouting disabled.