### PR TITLE
Fix Eloquent models key handling on Table

### DIFF
--- a/src/Bootstrapper/Table.php
+++ b/src/Bootstrapper/Table.php
@@ -355,7 +355,7 @@ class Table extends RenderedObject
 
         // Handles eloquent models
         if (is_callable([$item, 'getAttributes'])) {
-            return $item->getAttributes();
+            return array_keys($item->getAttributes());
         }
 
         // Default fallback


### PR DESCRIPTION
`Table::getKeysForItem()` has a (deprecated) bit of code to automatically handle Eloquent models. Though, this seems to be broken as it returns the actual attributes, and not its keys. This PR fixes it by calling `array_keys` on the attributes array that was previously returned.

I know this is deprecated, but I still think it's better to have the code working, specially since it's a incredibly simple alteration. Also, I used it as a guide to implement the `TableInterface` interface on my Eloquent models, which is the reason I found the bug in the first place.