### PR TITLE
Size could equal 0 or 12 and still be valid

### DIFF
--- a/src/Bootstrapper/ControlGroup.php
+++ b/src/Bootstrapper/ControlGroup.php
@@ -301,6 +301,6 @@ class ControlGroup extends RenderedObject
      */
     protected function sizeIsInvalid($size)
     {
-        return $size < 1 || $size > 11;
+        return $size < 0 || $size > 12;
     }
 }

--- a/src/Bootstrapper/ControlGroup.php
+++ b/src/Bootstrapper/ControlGroup.php
@@ -301,6 +301,6 @@ class ControlGroup extends RenderedObject
      */
     protected function sizeIsInvalid($size)
     {
-        return $size < 0 || $size > 12;
+        return $size < 1 || $size > 12;
     }
 }

--- a/tests/spec/Bootstrapper/ControlGroupSpec.php
+++ b/tests/spec/Bootstrapper/ControlGroupSpec.php
@@ -108,12 +108,6 @@ class ControlGroupSpec extends ObjectBehavior
         $this->shouldThrow(
             'Bootstrapper\\Exceptions\\ControlGroupException'
         )->duringWithLabel('', -1);
-        $this->shouldThrow(
-            'Bootstrapper\\Exceptions\\ControlGroupException'
-        )->duringWithLabel('', -0);
-        $this->shouldThrow(
-            'Bootstrapper\\Exceptions\\ControlGroupException'
-        )->duringWithLabel('', 12);
     }
 
     function it_handles_labels_correctly()

--- a/tests/spec/Bootstrapper/ControlGroupSpec.php
+++ b/tests/spec/Bootstrapper/ControlGroupSpec.php
@@ -108,6 +108,9 @@ class ControlGroupSpec extends ObjectBehavior
         $this->shouldThrow(
             'Bootstrapper\\Exceptions\\ControlGroupException'
         )->duringWithLabel('', -1);
+        $this->shouldThrow(
+            'Bootstrapper\\Exceptions\\ControlGroupException'
+        )->duringWithLabel('', -0);
     }
 
     function it_handles_labels_correctly()


### PR DESCRIPTION
Say you have 4+8, now it fails. But is valid for a Bootstrap row.

Also, it could be 1 as well, rare, but let's say a checkbox with no label.