### PR TITLE
resolve L5 form conflict

### DIFF
--- a/src/Bootstrapper/Form.php
+++ b/src/Bootstrapper/Form.php
@@ -5,14 +5,18 @@
 
 namespace Bootstrapper;
 
-use Illuminate\Html\FormBuilder;
+if (class_exists('\\Collective\\Html\\FormBuilder')) {
+	class FormBuilderConflict extends \Collective\Html\FormBuilder { }
+} else {
+	class FormBuilderConflict extends \Illuminate\Html\FormBuilder { }
+}
 
 /**
  * Creates Bootstrap 3 compliant forms
  *
  * @package Bootstrapper
  */
-class Form extends FormBuilder
+class Form extends FormBuilderConflict
 {
 
     /**

--- a/src/Bootstrapper/Form.php
+++ b/src/Bootstrapper/Form.php
@@ -5,12 +5,6 @@
 
 namespace Bootstrapper;
 
-if (class_exists('\\Collective\\Html\\FormBuilder')) {
-	class FormBuilderConflict extends \Collective\Html\FormBuilder { }
-} else {
-	class FormBuilderConflict extends \Illuminate\Html\FormBuilder { }
-}
-
 /**
  * Creates Bootstrap 3 compliant forms
  *

--- a/src/Bootstrapper/FormBuilderConflict.php
+++ b/src/Bootstrapper/FormBuilderConflict.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * Bootstrapper FormBuilderConflict class
+ */
+
+namespace Bootstrapper;
+
+// @codingStandardsIgnoreStart
+if (class_exists('\\Collective\\Html\\FormBuilder')) {
+    class FormBuilderConflict extends \Collective\Html\FormBuilder
+    {
+    }
+} else {
+    class FormBuilderConflict extends \Illuminate\Html\FormBuilder
+    {
+    }
+}
+// @codingStandardsIgnoreEnd


### PR DESCRIPTION
Resolve conflict between Laravel Form (L4) and LaravelCollective Form (L5)

This should solve issues discussed in:
https://github.com/patricktalmadge/bootstrapper/issues/279
https://github.com/patricktalmadge/bootstrapper/issues/292
https://github.com/LaravelCollective/html/issues/37

How?

It will simply check if you have Collective Form and use that and if not use standard Illuminate Form