### PR TITLE
tdClass Feature 

### DIFF
--- a/src/Bootstrapper/Table.php
+++ b/src/Bootstrapper/Table.php
@@ -65,6 +65,11 @@ class Table extends RenderedObject
     protected $only = [];
 
     /**
+     * @var string Class(es) to apply to body tds
+     */
+    protected $tdClass;
+
+    /**
      * Renders the table
      *
      * @return string
@@ -244,7 +249,7 @@ class Table extends RenderedObject
         foreach ($headers as $heading) {
             $value = $this->getValueForItem($item, $heading);
 
-            $string .= "<td>{$value}</td>";
+            $string .= empty($this->tdClass) ? "<td>{$value}</td>" : "<td class='{$this->tdClass}'>{$value}</td>";
         }
         $string .= '</tr>';
 
@@ -377,5 +382,21 @@ class Table extends RenderedObject
         }
 
         return $value;
+    }
+
+    /**
+     * Uses given class(es) on body TDs.
+     * @param  mixed $classes The class(es) to apply.
+     * @return $this
+     */
+    public function tdClass($classes)
+    {
+        if (is_array($classes)) {
+            $this->tdClass = implode(' ', $classes);
+        } else {
+            $this->tdClass = $classes;
+        }
+
+        return $this;
     }
 }

--- a/tests/spec/Bootstrapper/TableSpec.php
+++ b/tests/spec/Bootstrapper/TableSpec.php
@@ -185,6 +185,39 @@ class TableSpec extends ObjectBehavior
             "<table class='table'><thead><tr><th>foo</th><th>bar</th></tr></thead><tbody><tr><td>goo</td><td>gar</td></tr></tbody></table>"
         );
     }
+
+    function it_allows_specification_of_class_applied_to_all_tds()
+    {
+        $this->withContents(
+            [
+                [
+                    'foo'  => 'bar',
+                    'fizz' => 'buzz',
+                ]
+            ]
+        )->tdClass('vert-middle')->render()->shouldBe(
+            "<table class='table'><thead><tr><th>foo</th><th>fizz</th></tr></thead><tbody><tr><td class='vert-middle'>bar</td><td class='vert-middle'>buzz</td></tr></tbody></table>"
+        );
+    }
+
+    function it_allows_specification_of_td_classes_with_an_array()
+    {
+        $this->withContents(
+            [
+                [
+                    'foo'  => 'bar',
+                    'fizz' => 'buzz',
+                ]
+            ]
+        )->tdClass(
+            [
+                'vert-middle',
+                'text-right',
+            ]
+        )->render()->shouldBe(
+            "<table class='table'><thead><tr><th>foo</th><th>fizz</th></tr></thead><tbody><tr><td class='vert-middle text-right'>bar</td><td class='vert-middle text-right'>buzz</td></tr></tbody></table>"
+        );
+    }
 }
 
 class TableSpecFoo implements TableInterface

--- a/tests/spec/Bootstrapper/TableSpec.php
+++ b/tests/spec/Bootstrapper/TableSpec.php
@@ -186,7 +186,7 @@ class TableSpec extends ObjectBehavior
         );
     }
 
-    function it_allows_specification_of_class_applied_to_all_tds()
+    function it_allows_specification_of_class_applied_to_all_body_cells()
     {
         $this->withContents(
             [
@@ -195,12 +195,12 @@ class TableSpec extends ObjectBehavior
                     'fizz' => 'buzz',
                 ]
             ]
-        )->tdClass('vert-middle')->render()->shouldBe(
+        )->withBodyCellClass('vert-middle')->render()->shouldBe(
             "<table class='table'><thead><tr><th>foo</th><th>fizz</th></tr></thead><tbody><tr><td class='vert-middle'>bar</td><td class='vert-middle'>buzz</td></tr></tbody></table>"
         );
     }
 
-    function it_allows_specification_of_td_classes_with_an_array()
+    function it_allows_specification_of_body_cell_classes_with_an_array()
     {
         $this->withContents(
             [
@@ -209,13 +209,68 @@ class TableSpec extends ObjectBehavior
                     'fizz' => 'buzz',
                 ]
             ]
-        )->tdClass(
+        )->withBodyCellClass(
             [
                 'vert-middle',
                 'text-right',
             ]
         )->render()->shouldBe(
             "<table class='table'><thead><tr><th>foo</th><th>fizz</th></tr></thead><tbody><tr><td class='vert-middle text-right'>bar</td><td class='vert-middle text-right'>buzz</td></tr></tbody></table>"
+        );
+    }
+
+    function it_allows_specification_of_class_on_column()
+    {
+        $this->withContents(
+            [
+                [
+                    'foo' => 'bar',
+                    'fizz' => 'buzz',
+                ],
+                [
+                    'foo' => 'bar',
+                    'fizz' => 'buzz',
+                ]
+            ]
+        )->withClassOnCellsInColumn('fizz', 'text-right')->render()->shouldBe(
+            "<table class='table'><thead><tr><th>foo</th><th class='text-right'>fizz</th></tr></thead><tbody><tr><td>bar</td><td class='text-right'>buzz</td></tr><tr><td>bar</td><td class='text-right'>buzz</td></tr></tbody></table>"
+        );
+    }
+
+    function it_allows_specification_of_classes_on_column_with_array()
+    {
+        $this->withContents(
+            [
+                [
+                    'foo' => 'bar',
+                    'fizz' => 'buzz',
+                ],
+                [
+                    'foo' => 'bar',
+                    'fizz' => 'buzz',
+                ]
+            ]
+        )->withClassOnCellsInColumn('fizz', [ 'text-right', 'text-primary' ])->render()->shouldBe(
+            "<table class='table'><thead><tr><th>foo</th><th class='text-right text-primary'>fizz</th></tr></thead><tbody><tr><td>bar</td><td class='text-right text-primary'>buzz</td></tr><tr><td>bar</td><td class='text-right text-primary'>buzz</td></tr></tbody></table>"
+        );
+    }
+
+    function it_allows_specification_of_classes_on_multiple_columns_with_array()
+    {
+        $this->withContents(
+            [
+                [
+                    'foo' => 'bar',
+                    'fizz' => 'buzz',
+
+                ],
+                [
+                    'foo' => 'bar',
+                    'fizz' => 'buzz',
+                ]
+            ]
+        )->withClassOnCellsInColumn(['foo', 'fizz'], 'text-primary')->render()->shouldBe(
+            "<table class='table'><thead><tr><th class='text-primary'>foo</th><th class='text-primary'>fizz</th></tr></thead><tbody><tr><td class='text-primary'>bar</td><td class='text-primary'>buzz</td></tr><tr><td class='text-primary'>bar</td><td class='text-primary'>buzz</td></tr></tbody></table>"
         );
     }
 }


### PR DESCRIPTION
Hi, I would like the feature to be able to specify a class or more than one class to apply to all `<td>`s in the body.  Primarily this is useful to me (and I would assume others) for vertically centering text in a table when a button is present in a row (e.g., for actions).  See: http://stackoverflow.com/questions/13771101/centering-a-button-vertically-in-table-cell-using-twitter-bootstrap for a good example of why this could be useful.

I have implemented the feature and two tests for the feature which pass, let me know if you have any feedback you'd like me to implement.

The feature is simply a chainable `tdClass()` method which can take a string or an array of strings which specify the classes to be applied to all body tds.