### PR TITLE
added optional withHeaders method to Tables

### DIFF
--- a/src/Bootstrapper/Table.php
+++ b/src/Bootstrapper/Table.php
@@ -241,6 +241,11 @@ class Table extends RenderedObject
             }
         }
 
+        if(is_array($this->specialheaders)):
+            foreach($headers as $key=>$val):
+                if(!empty($this->specialheaders[$val])) $headers[$key] = $this->specialheaders[$val];
+            endforeach;
+        endif;
         return $headers;
     }
 
@@ -311,6 +316,11 @@ class Table extends RenderedObject
     {
         $this->only = $only;
 
+        return $this;
+    }
+
+    public function withHeaders(array $x){
+        $this->specialheaders = $x;
         return $this;
     }
 

--- a/src/Bootstrapper/Table.php
+++ b/src/Bootstrapper/Table.php
@@ -75,6 +75,8 @@ class Table extends RenderedObject
      */
     protected $columnClasses = [];
 
+    protected $headercaptions;
+
     /**
      * Renders the table
      *
@@ -241,11 +243,6 @@ class Table extends RenderedObject
             }
         }
 
-        if(is_array($this->specialheaders)):
-            foreach($headers as $key=>$val):
-                if(!empty($this->specialheaders[$val])) $headers[$key] = $this->specialheaders[$val];
-            endforeach;
-        endif;
         return $headers;
     }
 
@@ -319,8 +316,8 @@ class Table extends RenderedObject
         return $this;
     }
 
-    public function withHeaders(array $x){
-        $this->specialheaders = $x;
+    public function withHeaderCaptions(array $x){
+        $this->headercaptions = $x;
         return $this;
     }
 
@@ -331,6 +328,12 @@ class Table extends RenderedObject
         if (empty($headers)) {
             return '';
         }
+
+        if(is_array($this->headercaptions)):
+            foreach($headers as $key=>$val):
+                if(!empty($this->headercaptions[$val])) $headers[$key] = $this->headercaptions[$val];
+            endforeach;
+        endif;
 
         $string = '<thead><tr>';
         foreach ($headers as $heading) {


### PR DESCRIPTION
for specifying different colum names. (table headers) 

When you're using with pre defined arrays from controllers, they usually include database colum names which needs to be displayed properly and this method overrides the titles.

Let's say you have id,name,is_approved and timestamps on your companies object which you get from your ORM and converted to an array as expected to work with Tables.

like
```php
$companies= Company::all(['id','name','is_approved','created_at','updated_at'])->toArray();
```

Normally it should display those keys but now you can use it like to **override** certain fields.

```php
Table::withContents($companies)->withHeaders([
                        'is_approved' => 'Approval Status',
                        'created_at' => 'Creation Date',
                        'updated_at' => 'Last Update',
                    ])->callback('Actions', function ($field, $row) { 
                    return '<a class="btn btn-default" href="'.route('companies.edit',$row['id']).'">Edit</a>'.' <a class="btn btn-danger" href="'.route('companies.destroy',$row['id']).'">Delete</a>'; 
                });
```

Other fields like id and name would be displayed as themselves.
