### PR TITLE
Use csrf_token helper instead of token store.

### DIFF
--- a/src/Bootstrapper/BootstrapperL5ServiceProvider.php
+++ b/src/Bootstrapper/BootstrapperL5ServiceProvider.php
@@ -207,7 +207,7 @@ class BootstrapperL5ServiceProvider extends ServiceProvider
                     $app->make('collective::html'),
                     $app->make('url'),
                     $app->make('view'),
-                    $app['session.store']->getToken()
+                    csrf_token()
                 );
 
                 return $form->setSessionStore($app['session.store']);


### PR DESCRIPTION
Rather than directly access the token store, use the csrf_token helper
which should help future proof this service provider.

(e.g. in Laravel 5.3 the method was called `getToken()` but in 5.4 it
became just `token()`).