### PR TITLE
Drop support for HHVM and add PHP 7.2 in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,9 @@ sudo: false
 
 php:
   - 5.6
-  - hhvm
   - 7.0
   - 7.1
+  - 7.2
 
 before_install:
   - composer update


### PR DESCRIPTION
HHVM isn't support anymore by Laravel since version 5.4