### PR TITLE
fixed method signature to be compatible with collective/html 5.5.2+

### DIFF
--- a/src/Bootstrapper/Form.php
+++ b/src/Bootstrapper/Form.php
@@ -279,13 +279,14 @@ class Form extends FormBuilder
         $list = [],
         $selected = null,
         array $selectAttributes = [],
-        array $optionsAttributes = []
+        array $optionsAttributes = [],
+        array $optgroupsAttributes = []
     ) {
         $selectAttributes['class'] = isset($selectAttributes['class']) ?
             self::FORM_CONTROL . ' ' . $selectAttributes['class'] :
             self::FORM_CONTROL;
 
-        return parent::select($name, $list, $selected, $selectAttributes, $optionsAttributes);
+        return parent::select($name, $list, $selected, $selectAttributes, $optionsAttributes, $optgroupsAttributes);
     }
 
     /**


### PR DESCRIPTION
Hey there, due to the change here the method signature of `select()` changed slightly which is causing PHP errors in one of my projects. 

https://github.com/LaravelCollective/html/commit/2c5db92f662bf5dfb7b198265168599941e29de6#diff-36caabaf080d6afdac600a28bfcd238bR588

This PR adds the extra parameter to fix this.